### PR TITLE
mqtt-rpc-client: fix error response handling

### DIFF
--- a/bin/mqtt-rpc-client
+++ b/bin/mqtt-rpc-client
@@ -9,8 +9,9 @@ from urllib.parse import urlparse
 
 import paho_socket
 from jsonrpc.exceptions import JSONRPCError
-from mqttrpc.client import MQTTRPCError, TMQTTRPCClient
 from paho.mqtt import client as mqttclient
+
+from mqttrpc.client import MQTTRPCError, TMQTTRPCClient
 
 
 def main():

--- a/bin/mqtt-rpc-client
+++ b/bin/mqtt-rpc-client
@@ -7,7 +7,7 @@ import argparse
 
 from urllib.parse import urlparse
 from paho.mqtt import client as mqttclient
-from mqttrpc.client import TMQTTRPCClient
+from mqttrpc.client import TMQTTRPCClient, MQTTRPCError
 from jsonrpc.exceptions import JSONRPCError
 import paho_socket
 
@@ -64,10 +64,13 @@ def main():
     rpc_client = TMQTTRPCClient(client)
     client.on_message = rpc_client.on_mqtt_message
 
-    resp = rpc_client.call(
-        args.driver, args.service, args.method, args.args, args.timeout
-    )
-    pprint.pprint(resp)
+    try:
+        resp = rpc_client.call(
+            args.driver, args.service, args.method, args.args, args.timeout
+        )
+        pprint.pprint(resp)
+    except MQTTRPCError as e:
+        print("Error: %s" % e)
 
 
 if __name__ == "__main__":

--- a/bin/mqtt-rpc-client
+++ b/bin/mqtt-rpc-client
@@ -1,49 +1,33 @@
 #!/usr/bin/env python3
 
-import os
-import json, time
-import pprint
 import argparse
-
+import json
+import os
+import pprint
+import time
 from urllib.parse import urlparse
-from paho.mqtt import client as mqttclient
-from mqttrpc.client import TMQTTRPCClient, MQTTRPCError
-from jsonrpc.exceptions import JSONRPCError
+
 import paho_socket
+from jsonrpc.exceptions import JSONRPCError
+from mqttrpc.client import MQTTRPCError, TMQTTRPCClient
+from paho.mqtt import client as mqttclient
 
 
 def main():
     parser = argparse.ArgumentParser(description="Sample RPC client", add_help=False)
     parser.add_argument(
-        "-b", "--broker_url", dest="broker_url", type=str, help="MQTT url", default="unix:///var/run/mosquitto/mosquitto.sock"
-    )
-    parser.add_argument(
-        "-d",
-        "--driver",
-        dest="driver",
+        "-b",
+        "--broker_url",
+        dest="broker_url",
         type=str,
-        help="Driver name"
+        help="MQTT url",
+        default="unix:///var/run/mosquitto/mosquitto.sock",
     )
-    parser.add_argument(
-        "-s",
-        "--service",
-        dest="service",
-        type=str,
-        help="Service name"
-    )
-    parser.add_argument(
-        "-m",
-        "--method",
-        dest="method",
-        type=str,
-        help="Method name"
-    )
-    parser.add_argument(
-        "-a", "--args", dest="args", type=json.loads, help="Method arguments"
-    )
-    parser.add_argument(
-        "-t", "--timeout", dest="timeout", type=int, help="Timeout", default=10
-    )
+    parser.add_argument("-d", "--driver", dest="driver", type=str, help="Driver name")
+    parser.add_argument("-s", "--service", dest="service", type=str, help="Service name")
+    parser.add_argument("-m", "--method", dest="method", type=str, help="Method name")
+    parser.add_argument("-a", "--args", dest="args", type=json.loads, help="Method arguments")
+    parser.add_argument("-t", "--timeout", dest="timeout", type=int, help="Timeout", default=10)
     args = parser.parse_args()
 
     url = urlparse(args.broker_url)
@@ -65,9 +49,7 @@ def main():
     client.on_message = rpc_client.on_mqtt_message
 
     try:
-        resp = rpc_client.call(
-            args.driver, args.service, args.method, args.args, args.timeout
-        )
+        resp = rpc_client.call(args.driver, args.service, args.method, args.args, args.timeout)
         pprint.pprint(resp)
     except MQTTRPCError as e:
         print("Error: %s" % e)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-mqttrpc (1.1.7) stable; urgency=medium
+
+  * mqtt-rpc-client: fix error response handling
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 03 Feb 2023 13:17:00 +0400
+
 python-mqttrpc (1.1.6) stable; urgency=medium
 
   * Fix formatting

--- a/editor_client.py
+++ b/editor_client.py
@@ -14,10 +14,11 @@ def main():
     rpc_client = mqttrpc.client.TMQTTRPCClient(mqttClient)
     mqttClient.on_message = rpc_client.on_mqtt_message
 
-    resp = rpc_client.call('wbrules', 'Editor', 'List', {'path': '/'})
-    print resp
+    resp = rpc_client.call("wbrules", "Editor", "List", {"path": "/"})
+    print(resp)
 
     raw_input()
+
 
 if __name__ == "__main__":
     main()

--- a/mqttrpc/client.py
+++ b/mqttrpc/client.py
@@ -93,7 +93,11 @@ class TMQTTRPCClient(object):
 
         if result.error:
             future.set_exception(
-                MQTTRPCError(result.error["message"], result.error["code"], result.error["data"])
+                MQTTRPCError(
+                    result.error["message"],
+                    result.error["code"],
+                    result.error["data"] if "data" in result.error else None,
+                )
             )
 
         future.set_result(result.result)

--- a/server.py
+++ b/server.py
@@ -15,10 +15,10 @@ from mqttrpc import MQTTRPCResponseManager, dispatcher
 
 logging.getLogger().setLevel(logging.DEBUG)
 
+
 @dispatcher.add_method
 def foobar(**kwargs):
     return kwargs["foo"] + kwargs["bar"]
-
 
 
 class TMQTTRPCServer(object):
@@ -27,20 +27,20 @@ class TMQTTRPCServer(object):
         self.driver_id = driver_id
 
     def on_mqtt_message(self, mosq, obj, msg):
-        print msg.topic
-        print msg.payload
+        print(msg.topic)
+        print(msg.payload)
 
-        parts = msg.topic.split('/')
+        parts = msg.topic.split("/")
         driver_id = parts[3]
         service_id = parts[4]
         method_id = parts[5]
         client_id = parts[6]
 
-
         response = MQTTRPCResponseManager.handle(msg.payload, service_id, method_id, dispatcher)
 
-        self.client.publish("/rpc/v1/%s/%s/%s/%s/reply" % (self.driver_id, service_id, method_id, client_id ), response.json)
-
+        self.client.publish(
+            "/rpc/v1/%s/%s/%s/%s/reply" % (self.driver_id, service_id, method_id, client_id), response.json
+        )
 
     def setup(self):
         for service, method in dispatcher.iterkeys():
@@ -49,31 +49,21 @@ class TMQTTRPCServer(object):
             self.client.subscribe("/rpc/v1/%s/%s/%s/+" % (self.driver_id, service, method))
 
 
-
-
-
-
 # Dispatcher is dictionary {<method_name>: callable}
 dispatcher[("test", "echo")] = lambda s: s
 dispatcher[("test", "add")] = lambda a, b: a + b
 
 
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Sample RPC server", add_help=False)
 
+    parser.add_argument("-h", "--host", dest="host", type=str, help="MQTT host", default="localhost")
 
-if __name__ =='__main__':
-    parser = argparse.ArgumentParser(description='Sample RPC server', add_help=False)
+    parser.add_argument("-u", "--username", dest="username", type=str, help="MQTT username", default="")
 
-    parser.add_argument('-h', '--host', dest='host', type=str,
-                     help='MQTT host', default='localhost')
+    parser.add_argument("-P", "--password", dest="password", type=str, help="MQTT password", default="")
 
-    parser.add_argument('-u', '--username', dest='username', type=str,
-                     help='MQTT username', default='')
-
-    parser.add_argument('-P', '--password', dest='password', type=str,
-                     help='MQTT password', default='')
-
-    parser.add_argument('-p', '--port', dest='port', type=int,
-                     help='MQTT port', default='1883')
+    parser.add_argument("-p", "--port", dest="port", type=int, help="MQTT port", default="1883")
 
     args = parser.parse_args()
     client = mosquitto.Mosquitto()
@@ -81,13 +71,11 @@ if __name__ =='__main__':
     if args.username:
         client.username_pw_set(args.username, args.password)
 
-
-    rpc_server = TMQTTRPCServer(client, 'Driver')
+    rpc_server = TMQTTRPCServer(client, "Driver")
 
     client.connect(args.host, args.port)
     client.on_message = rpc_server.on_mqtt_message
     rpc_server.setup()
-
 
     while 1:
         rc = client.loop()


### PR DESCRIPTION
`data` is optional field in error response, see [MQTT-RPC protocol](https://github.com/wirenboard/mqtt-rpc).

Before:
```sh
$ mqtt-rpc-client -d wb-device-manager -s bus-scan -m Stop
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.9/threading.py", line 954, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.9/threading.py", line 892, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 3452, in _thread_main
    self.loop_forever(retry_first_connection=True)
  File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 1779, in loop_forever
    rc = self.loop(timeout, max_packets)
  File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 1181, in loop
    rc = self.loop_read(max_packets)
  File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 1572, in loop_read
    rc = self._packet_read()
  File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 2310, in _packet_read
    rc = self._packet_handle()
  File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 2936, in _packet_handle
    return self._handle_publish()
  File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 3216, in _handle_publish
    self._handle_on_message(message)
  File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 3444, in _handle_on_message
    self.on_message(self, self._userdata, message)
  File "/usr/lib/python3/dist-packages/mqttrpc/client.py", line 96, in on_mqtt_message
    MQTTRPCError(result.error["message"], result.error["code"], result.error["data"])
KeyError: 'data'
Traceback (most recent call last):
  File "/usr/bin/mqtt-rpc-client", line 74, in <module>
    main()
  File "/usr/bin/mqtt-rpc-client", line 67, in main
    resp = rpc_client.call(
  File "/usr/lib/python3/dist-packages/mqttrpc/client.py", line 111, in call
    raise err
  File "/usr/lib/python3/dist-packages/mqttrpc/client.py", line 107, in call
    result = future.result(1e100 if timeout is None else timeout)
  File "/usr/lib/python3/dist-packages/mqttrpc/client.py", line 56, in result
    raise TimeoutError()
mqttrpc.client.TimeoutError
```

After:
```sh
$ mqtt-rpc-client -d wb-device-manager -s bus-scan -m Stop
Error: Task is already executing. [-33100]: None
```