### PR TITLE
mqtt-rpc-client: fix timeout handling

### DIFF
--- a/bin/mqtt-rpc-client
+++ b/bin/mqtt-rpc-client
@@ -28,7 +28,7 @@ def main():
     parser.add_argument("-s", "--service", dest="service", type=str, help="Service name")
     parser.add_argument("-m", "--method", dest="method", type=str, help="Method name")
     parser.add_argument("-a", "--args", dest="args", type=json.loads, help="Method arguments")
-    parser.add_argument("-t", "--timeout", dest="timeout", type=int, help="Timeout", default=10)
+    parser.add_argument("-t", "--timeout", dest="timeout", type=int, help="Timeout in seconds", default=10)
     args = parser.parse_args()
 
     url = urlparse(args.broker_url)

--- a/bin/mqtt-rpc-client
+++ b/bin/mqtt-rpc-client
@@ -11,7 +11,7 @@ import paho_socket
 from jsonrpc.exceptions import JSONRPCError
 from paho.mqtt import client as mqttclient
 
-from mqttrpc.client import TimeoutError, MQTTRPCError, TMQTTRPCClient
+from mqttrpc.client import MQTTRPCError, TimeoutError, TMQTTRPCClient
 
 
 def main():

--- a/bin/mqtt-rpc-client
+++ b/bin/mqtt-rpc-client
@@ -11,7 +11,7 @@ import paho_socket
 from jsonrpc.exceptions import JSONRPCError
 from paho.mqtt import client as mqttclient
 
-from mqttrpc.client import MQTTRPCError, TMQTTRPCClient
+from mqttrpc.client import TimeoutError, MQTTRPCError, TMQTTRPCClient
 
 
 def main():
@@ -54,6 +54,8 @@ def main():
         pprint.pprint(resp)
     except MQTTRPCError as e:
         print("Error: %s" % e)
+    except TimeoutError:
+        print("Request timed out")
 
 
 if __name__ == "__main__":

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-mqttrpc (1.1.8) stable; urgency=medium
+
+  * mqtt-rpc-client: fix timeout handling
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 15 Feb 2023 13:15:00 +0400
+
 python-mqttrpc (1.1.7) stable; urgency=medium
 
   * mqtt-rpc-client: fix error response handling


### PR DESCRIPTION
Before:
```sh
$ mqtt-rpc-client -d wb-mqtt-serial -s port -m Load -a "{...}"
Traceback (most recent call last):
  File "/usr/bin/mqtt-rpc-client", line 60, in <module>
    main()
  File "/usr/bin/mqtt-rpc-client", line 53, in main
    resp = rpc_client.call(args.driver, args.service, args.method, args.args, args.timeout)
  File "/usr/lib/python3/dist-packages/mqttrpc/client.py", line 115, in call
    raise err
  File "/usr/lib/python3/dist-packages/mqttrpc/client.py", line 111, in call
    result = future.result(1e100 if timeout is None else timeout)
  File "/usr/lib/python3/dist-packages/mqttrpc/client.py", line 56, in result
    raise TimeoutError()
mqttrpc.client.TimeoutError
```

After:
```sh
$ mqtt-rpc-client -d wb-mqtt-serial -s port -m Load -a "{...}"
Request timed out
```