### PR TITLE
mqtt-rpc-client: use mqtt client wrapper from wb-common

### DIFF
--- a/bin/mqtt-rpc-client
+++ b/bin/mqtt-rpc-client
@@ -31,7 +31,7 @@ def main():
         mqtt_client = MQTTClient("mqtt-rpc-client", args.broker_url)
         rpc_client = TMQTTRPCClient(mqtt_client)
         mqtt_client.on_message = rpc_client.on_mqtt_message
-        mqtt_client.connect()
+        mqtt_client.start()
 
         resp = rpc_client.call(args.driver, args.service, args.method, args.args, args.timeout)
         pprint.pprint(resp)
@@ -39,6 +39,8 @@ def main():
         print("Request timed out")
     except Exception as e:
         print("Error: %s" % e)
+    finally:
+        mqtt_client.stop()
 
 
 if __name__ == "__main__":

--- a/bin/mqtt-rpc-client
+++ b/bin/mqtt-rpc-client
@@ -6,7 +6,7 @@ import pprint
 
 from jsonrpc.exceptions import JSONRPCError
 from mqttrpc.client import MQTTRPCError, TimeoutError, TMQTTRPCClient
-from wb_common.mqtt_client import MQTTClient
+from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
 
 
 def main():
@@ -17,7 +17,7 @@ def main():
         dest="broker_url",
         type=str,
         help="MQTT broker url",
-        default="unix:///var/run/mosquitto/mosquitto.sock",
+        default=DEFAULT_BROKER_URL,
     )
     parser.add_argument("-d", "--driver", dest="driver", type=str, help="Driver name")
     parser.add_argument("-s", "--service", dest="service", type=str, help="Service name")

--- a/bin/mqtt-rpc-client
+++ b/bin/mqtt-rpc-client
@@ -2,26 +2,21 @@
 
 import argparse
 import json
-import os
 import pprint
-import time
-from urllib.parse import urlparse
 
-import paho_socket
 from jsonrpc.exceptions import JSONRPCError
-from paho.mqtt import client as mqttclient
-
 from mqttrpc.client import MQTTRPCError, TimeoutError, TMQTTRPCClient
+from wb_common.mqtt_client import MQTTClient
 
 
 def main():
     parser = argparse.ArgumentParser(description="Sample RPC client", add_help=False)
     parser.add_argument(
         "-b",
-        "--broker_url",
+        "--broker",
         dest="broker_url",
         type=str,
-        help="MQTT url",
+        help="MQTT broker url",
         default="unix:///var/run/mosquitto/mosquitto.sock",
     )
     parser.add_argument("-d", "--driver", dest="driver", type=str, help="Driver name")
@@ -31,31 +26,18 @@ def main():
     parser.add_argument("-t", "--timeout", dest="timeout", type=int, help="Timeout in seconds", default=10)
     args = parser.parse_args()
 
-    url = urlparse(args.broker_url)
-    client_id = "mqtt-rpc-client-%d" % os.getpid()
-    if url.scheme == "mqtt-tcp":
-        client = mqttclient.Client(client_id)
-        if url.username:
-            client.username_pw_set(url.username, url.password)
-        client.connect(url.hostname, url.port)
-    elif url.scheme == "unix":
-        client = paho_socket.Client(client_id)
-        client.sock_connect(url.path)
-    else:
-        print("Unkown mqtt url scheme")
-        exit(1)
-    client.loop_start()
-
-    rpc_client = TMQTTRPCClient(client)
-    client.on_message = rpc_client.on_mqtt_message
-
     try:
+        mqtt_client = MQTTClient("mqtt-rpc-client", args.broker_url)
+        rpc_client = TMQTTRPCClient(mqtt_client)
+        mqtt_client.on_message = rpc_client.on_mqtt_message
+        mqtt_client.connect()
+
         resp = rpc_client.call(args.driver, args.service, args.method, args.args, args.timeout)
         pprint.pprint(resp)
-    except MQTTRPCError as e:
-        print("Error: %s" % e)
     except TimeoutError:
         print("Request timed out")
+    except Exception as e:
+        print("Error: %s" % e)
 
 
 if __name__ == "__main__":

--- a/bin/mqtt-rpc-client
+++ b/bin/mqtt-rpc-client
@@ -5,8 +5,9 @@ import json
 import pprint
 
 from jsonrpc.exceptions import JSONRPCError
-from mqttrpc.client import MQTTRPCError, TimeoutError, TMQTTRPCClient
 from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
+
+from mqttrpc.client import MQTTRPCError, TimeoutError, TMQTTRPCClient
 
 
 def main():

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-mqttrpc (1.1.9) stable; urgency=medium
+
+  * mqtt-rpc-client: use mqtt client wrapper from wb-common
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 28 Feb 2023 18:39:00 +0400
+
 python-mqttrpc (1.1.8) stable; urgency=medium
 
   * mqtt-rpc-client: fix timeout handling

--- a/debian/control
+++ b/debian/control
@@ -9,5 +9,5 @@ X-Python3-Version: >= 3.5
 Package: python3-mqttrpc
 Architecture: all
 XB-Python-Version: ${python3:Version}
-Depends: python3, ${misc:Depends}, ${shlibs:Depends}, python3-json-rpc, python3-paho-mqtt, python3-paho-socket, python3-mqttrpc
+Depends: python3, ${misc:Depends}, ${shlibs:Depends}, python3-json-rpc, python3-paho-mqtt, python3-wb-common (>= 2.1.0), python3-mqttrpc
 Description: Reference MQTT-RPC implementation

--- a/mqttrpc/client.py
+++ b/mqttrpc/client.py
@@ -1,12 +1,7 @@
 import json
-
-try:
-    import mosquitto
-except ImportError:
-    import paho.mqtt.client as mosquitto
-
 import threading
 
+import paho.mqtt.client as mqtt
 from jsonrpc.exceptions import JSONRPCError
 
 # ~ from concurrent.futures import Future
@@ -76,7 +71,7 @@ class TMQTTRPCClient(object):
     def on_mqtt_message(self, mosq, obj, msg):
         """return True if the message was indeed an rpc call"""
 
-        if not mosquitto.topic_matches_sub("/rpc/v1/+/+/+/%s/reply" % self.rpc_client_id, msg.topic):
+        if not mqtt.topic_matches_sub("/rpc/v1/+/+/+/%s/reply" % self.rpc_client_id, msg.topic):
             return
 
         parts = msg.topic.split("/")


### PR DESCRIPTION
Depends on https://github.com/wirenboard/wb-common/pull/8

How to test:
```sh
$ mqtt-rpc-client -d wb-mqtt-serial -s ports -m Load
$ mqtt-rpc-client -b unix:///var/run/mosquitto/mosquitto.sock -d wb-mqtt-serial -s ports -m Load
$ mqtt-rpc-client -b tcp://127.0.0.1:1883 -d wb-mqtt-serial -s port -m Load
$ mqtt-rpc-client -b tcp://user:password@127.0.0.1:1883 -d wb-mqtt-serial -s port -m Load
$ mqtt-rpc-client -b ws://127.0.0.1:18883 -d wb-mqtt-serial -s ports -m Load
$ mqtt-rpc-client -b ws://127.0.0.1:18883/mqtt -d wb-mqtt-serial -s ports -m Load
```