### PR TITLE
mqtt-rpc-client: print response as JSON

### DIFF
--- a/bin/mqtt-rpc-client
+++ b/bin/mqtt-rpc-client
@@ -2,7 +2,6 @@
 
 import argparse
 import json
-import pprint
 
 from jsonrpc.exceptions import JSONRPCError
 from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
@@ -11,7 +10,9 @@ from mqttrpc.client import MQTTRPCError, TimeoutError, TMQTTRPCClient
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Sample RPC client", add_help=False)
+    parser = argparse.ArgumentParser(
+        description="Sample RPC client", add_help=True, formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
     parser.add_argument(
         "-b",
         "--broker",
@@ -20,9 +21,9 @@ def main():
         help="MQTT broker url",
         default=DEFAULT_BROKER_URL,
     )
-    parser.add_argument("-d", "--driver", dest="driver", type=str, help="Driver name")
-    parser.add_argument("-s", "--service", dest="service", type=str, help="Service name")
-    parser.add_argument("-m", "--method", dest="method", type=str, help="Method name")
+    parser.add_argument("-d", "--driver", dest="driver", type=str, help="Driver name", required=True)
+    parser.add_argument("-s", "--service", dest="service", type=str, help="Service name", required=True)
+    parser.add_argument("-m", "--method", dest="method", type=str, help="Method name", required=True)
     parser.add_argument("-a", "--args", dest="args", type=json.loads, help="Method arguments")
     parser.add_argument("-t", "--timeout", dest="timeout", type=int, help="Timeout in seconds", default=10)
     args = parser.parse_args()
@@ -34,7 +35,7 @@ def main():
         mqtt_client.start()
 
         resp = rpc_client.call(args.driver, args.service, args.method, args.args, args.timeout)
-        pprint.pprint(resp)
+        print(json.dumps(resp))
     except TimeoutError:
         print("Request timed out")
     except Exception as e:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-mqttrpc (1.2.0) stable; urgency=medium
+
+  * mqtt-rpc-client: print response as JSON
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 16 Mar 2023 13:37:00 +0400
+
 python-mqttrpc (1.1.9) stable; urgency=medium
 
   * mqtt-rpc-client: use mqtt client wrapper from wb-common


### PR DESCRIPTION
Before:
```sh
$ mqtt-rpc-client -d wb-mqtt-serial -s metrics -m Load | jq
parse error: Invalid numeric literal at line 1, column 13
$ mqtt-rpc-client
Request timed out
$ mqtt-rpc-client -h
usage: mqtt-rpc-client [-b BROKER_URL] [-d DRIVER] [-s SERVICE] [-m METHOD] [-a ARGS] [-t TIMEOUT]
mqtt-rpc-client: error: unrecognized arguments: -h
```
After:
```sh
$ mqtt-rpc-client -d wb-mqtt-serial -s metrics -m Load | jq | head
[
  {
    "channels": [
      {
        "bl": "0.00",
        "bl15": "0.00",
        "i50": 305,
        "i95": 310,
        "names": [
          "idle"
$ mqtt-rpc-client
usage: mqtt-rpc-client [-h] [-b BROKER_URL] -d DRIVER -s SERVICE -m METHOD [-a ARGS] [-t TIMEOUT]
mqtt-rpc-client: error: the following arguments are required: -d/--driver, -s/--service, -m/--method
$ mqtt-rpc-client -h
usage: mqtt-rpc-client [-h] [-b BROKER_URL] -d DRIVER -s SERVICE -m METHOD [-a ARGS] [-t TIMEOUT]

Sample RPC client

optional arguments:
  -h, --help            show this help message and exit
  -b BROKER_URL, --broker BROKER_URL
                        MQTT broker url (default: unix:///var/run/mosquitto/mosquitto.sock)
  -d DRIVER, --driver DRIVER
                        Driver name (default: None)
  -s SERVICE, --service SERVICE
                        Service name (default: None)
  -m METHOD, --method METHOD
                        Method name (default: None)
  -a ARGS, --args ARGS  Method arguments (default: None)
  -t TIMEOUT, --timeout TIMEOUT
                        Timeout in seconds (default: 10)
```