### PR TITLE
add Homepage to debian/control (no functional changes)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-mqttrpc (1.2.1) stable; urgency=medium
+
+  * add Homepage to debian/control (no functional changes)
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 30 Mar 2023 16:38:06 +0600
+
 python-mqttrpc (1.2.0) stable; urgency=medium
 
   * mqtt-rpc-client: print response as JSON

--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Priority: optional
 Build-Depends: python3, dh-python, python3-setuptools, debhelper (>= 9)
 Standards-Version: 3.9.1
 X-Python3-Version: >= 3.5
+Homepage: https://github.com/wirenboard/python-mqtt-rpc
 
 Package: python3-mqttrpc
 Architecture: all


### PR DESCRIPTION
По мотивам https://github.com/wirenboard/wb-ci-tools/pull/20#issuecomment-1490022448

Нужно, чтобы пакет не считался contrib