### PR TITLE
mqtt-rpc-client: fix default value of --args option

### DIFF
--- a/bin/mqtt-rpc-client
+++ b/bin/mqtt-rpc-client
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=invalid-name
 
 import argparse
 import json
@@ -24,7 +25,7 @@ def main():
     parser.add_argument("-d", "--driver", dest="driver", type=str, help="Driver name", required=True)
     parser.add_argument("-s", "--service", dest="service", type=str, help="Service name", required=True)
     parser.add_argument("-m", "--method", dest="method", type=str, help="Method name", required=True)
-    parser.add_argument("-a", "--args", dest="args", type=json.loads, help="Method arguments")
+    parser.add_argument("-a", "--args", dest="args", type=json.loads, help="Method arguments", default={})
     parser.add_argument("-t", "--timeout", dest="timeout", type=int, help="Timeout in seconds", default=10)
     args = parser.parse_args()
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-mqttrpc (1.2.3) stable; urgency=medium
+
+  * mqtt-rpc-client: fix default value of --args option
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 24 Jan 2024 16:00:00 +0400
+
 python-mqttrpc (1.2.2) stable; urgency=medium
 
   * Fix PKG-INFO


### PR DESCRIPTION
Многие RPC методы не имеют параметров, но сейчас если не передать явно пустой объект `-a '{}'`, то в запросе будет `"params": null`, хотя согласно [описанию](https://github.com/wirenboard/mqtt-rpc) формально там должно быть "JSON-объект или массив значений", но не null.
Некоторые сервисы тем не менее понимают null в params:
```sh
mqtt-rpc-client -d wb-mqtt-serial -s ports -m Load
[{"baud_rate": 115200, "data_bits": 8, "parity": "N", "path": "/dev/ttyRS485-1", "stop_bits": 2}, {"baud_rate": 9600, "data_bits": 8, "parity": "N", "path": "/dev/ttyRS485-2", "stop_bits": 2}]
```
Но некоторые не понимают:
```sh
mqtt-rpc-client -d confed -s Editor -m List
Error: Invalid params [-32602]: None
```