### PR TITLE
Fix error handling

### DIFF
--- a/bin/mqtt-rpc-client
+++ b/bin/mqtt-rpc-client
@@ -3,6 +3,7 @@
 
 import argparse
 import json
+import sys
 
 from jsonrpc.exceptions import JSONRPCError
 from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
@@ -39,11 +40,16 @@ def main():
         print(json.dumps(resp))
     except TimeoutError:
         print("Request timed out")
+        sys.exit(124)
     except Exception as e:
         print("Error: %s" % e)
+        sys.exit(1)
     finally:
         mqtt_client.stop()
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-mqttrpc (1.2.4) stable; urgency=medium
+
+  * mqtt-rpc-client: fix error handling
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 29 Jan 2024 16:15:00 +0400
+
 python-mqttrpc (1.2.3) stable; urgency=medium
 
   * mqtt-rpc-client: fix default value of --args option


### PR DESCRIPTION
```sh
$ mqtt-rpc-client -d wb-mqtt-seria -s ports -m Load
^CTraceback (most recent call last):
  File "/usr/bin/mqtt-rpc-client", line 52, in <module>
    main()
  File "/usr/bin/mqtt-rpc-client", line 39, in main
    resp = rpc_client.call(args.driver, args.service, args.method, args.args, args.timeout)
  File "/usr/lib/python3/dist-packages/mqttrpc/client.py", line 106, in call
    result = future.result(1e100 if timeout is None else timeout)
  File "/usr/lib/python3/dist-packages/mqttrpc/client.py", line 48, in result
    if self._event.wait(timeout):
  File "/usr/lib/python3.9/threading.py", line 574, in wait
    signaled = self._cond.wait(timeout)
  File "/usr/lib/python3.9/threading.py", line 316, in wait
    gotit = waiter.acquire(True, timeout)
KeyboardInterrupt
```