### PR TITLE
Use python3-jsonrpc

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,3 @@
 buildDebArchAll defaultRunPythonChecks: true,
+                defaultRunLintian: true,
                 repos: ['release', 'devTools']

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-mqttrpc (1.3.0) stable; urgency=medium
+
+  * Use python3-jsonrpc
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 31 Mar 2025 16:15:00 +0400
+
 python-mqttrpc (1.2.5) stable; urgency=medium
 
   * Fix exception processing

--- a/debian/control
+++ b/debian/control
@@ -1,5 +1,5 @@
 Source: python-mqttrpc
-Maintainer: Evgeny Boger <boger@contactless.ru>
+Maintainer: Wiren Board team <info@wirenboard.com>
 Section: python
 Priority: optional
 Build-Depends: python3, dh-python, python3-setuptools, debhelper (>= 9)
@@ -10,5 +10,6 @@ Homepage: https://github.com/wirenboard/python-mqtt-rpc
 Package: python3-mqttrpc
 Architecture: all
 XB-Python-Version: ${python3:Version}
-Depends: python3, ${misc:Depends}, ${shlibs:Depends}, python3-json-rpc, python3-paho-mqtt, python3-wb-common (>= 2.1.0)
+Depends: python3, ${misc:Depends}, ${shlibs:Depends}, python3-jsonrpc, python3-paho-mqtt, python3-wb-common (>= 2.1.0)
 Description: Reference MQTT-RPC implementation
+ Python implementation of MQTT-RPC.

--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,6 @@ Homepage: https://github.com/wirenboard/python-mqtt-rpc
 Package: python3-mqttrpc
 Architecture: all
 XB-Python-Version: ${python3:Version}
-Depends: python3, ${misc:Depends}, ${shlibs:Depends}, python3-jsonrpc, python3-paho-mqtt, python3-wb-common (>= 2.1.0)
+Depends: python3, ${misc:Depends}, ${shlibs:Depends}, python3-jsonrpc | python3-json-rpc, python3-paho-mqtt, python3-wb-common (>= 2.1.0)
 Description: Reference MQTT-RPC implementation
  Python implementation of MQTT-RPC.


### PR DESCRIPTION
В булзае уже есть 1.13.0 https://packages.debian.org/bullseye/python3-jsonrpc.
Существующие инсталяции продолжат использовать python3-json-rpc, в следующих релизах когда выкинем python3-json-rpc, уже будет работать с python3-jsonrpc.