### PR TITLE
Remove six usage

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-mqttrpc (1.3.1) stable; urgency=medium
+
+  * Remove six usage
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 23 Apr 2025 16:15:00 +0400
+
 python-mqttrpc (1.3.0) stable; urgency=medium
 
   * Use python3-jsonrpc

--- a/mqttrpc/protocol.py
+++ b/mqttrpc/protocol.py
@@ -1,6 +1,5 @@
 import json
 
-from jsonrpc import six
 from jsonrpc.exceptions import JSONRPCError, JSONRPCInvalidRequestException
 from jsonrpc.utils import JSONSerializable
 
@@ -143,7 +142,7 @@ class MQTTRPC10Request(MQTTRPCBaseRequest):
 
     @_id.setter
     def _id(self, value):
-        if value is not None and not isinstance(value, six.string_types + six.integer_types):
+        if value is not None and not isinstance(value, (str, int)):
             raise ValueError("id should be string or integer")
 
         self._data["id"] = value
@@ -253,7 +252,7 @@ class MQTTRPC10Response(MQTTRPCBaseResponse):
 
     @_id.setter
     def _id(self, value):
-        if value is not None and not isinstance(value, six.string_types + six.integer_types):
+        if value is not None and not isinstance(value, (str, int)):
             raise ValueError("id should be string or integer")
 
         self._data["id"] = value

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 def get_version():
     with open("debian/changelog", "r", encoding="utf-8") as f:
-        return f.readline().split()[1][1:-1]
+        return f.readline().split()[1][1:-1].split("~")[0]
 
 
 def read(fname):


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
* При использовании со свежим jsonrpc на debian 13:
```sh
/usr/lib/python3/dist-packages/mqttrpc/protocol.py:3: in <module>
    from jsonrpc import six
E   ImportError: cannot import name 'six' from 'jsonrpc' (/usr/lib/python3/dist-packages/jsonrpc/__init__.py)
```
* PEP 440

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


