### PR TITLE
Add install requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 ### Python ###
+build/
 *.egg-info/
 .venv
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-mqttrpc (1.3.4) stable; urgency=medium
+
+  * Add install requirements, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 03 Dec 2025 16:15:00 +0400
+
 python-mqttrpc (1.3.3) stable; urgency=medium
 
   * Handle wrong response structures more gracefully
@@ -6,7 +12,7 @@ python-mqttrpc (1.3.3) stable; urgency=medium
 
 python-mqttrpc (1.3.2) stable; urgency=medium
 
-  * Enable angry pylint. No functional changes 
+  * Enable angry pylint. No functional changes
 
  -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Fri, 23 May 2025 12:17:05 +0300
 

--- a/debian/control
+++ b/debian/control
@@ -3,13 +3,13 @@ Maintainer: Wiren Board team <info@wirenboard.com>
 Section: python
 Priority: optional
 Build-Depends: python3, dh-python, python3-setuptools, debhelper (>= 9)
-Standards-Version: 3.9.1
-X-Python3-Version: >= 3.5
+Standards-Version: 4.5.1
+X-Python3-Version: >= 3.9
 Homepage: https://github.com/wirenboard/python-mqtt-rpc
 
 Package: python3-mqttrpc
 Architecture: all
 XB-Python-Version: ${python3:Version}
-Depends: python3, ${misc:Depends}, ${shlibs:Depends}, python3-jsonrpc | python3-json-rpc, python3-paho-mqtt, python3-wb-common (>= 2.1.0)
+Depends: python3, ${misc:Depends}, ${shlibs:Depends}, python3-jsonrpc, python3-paho-mqtt, python3-wb-common (>= 2.1.0)
 Description: Reference MQTT-RPC implementation
  Python implementation of MQTT-RPC.

--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -1,0 +1,1 @@
+wb_common_ python3-wb-common-

--- a/setup.py
+++ b/setup.py
@@ -47,4 +47,9 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     license="MIT",
+    install_requires=[
+        "json-rpc==1.13.0",
+        "paho-mqtt==1.5.1",
+        "wb-common @ git+https://github.com/wirenboard/wb-common.git@master",
+    ],
 )


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
* добавлен install_requires, чтобы при локальной установке через pip подтягивались и зависимости
* python3-json-rpc удален из реп начиная с 2504 релиза

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**


