### PR TITLE
Fix dependencies

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-mqttrpc (1.3.8) stable; urgency=medium
+
+  * Fix dependencies
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 19 Jun 2026 17:40:00 +0400
+
 python-mqttrpc (1.3.7) stable; urgency=medium
 
   * Fix dependencies, no functional changes

--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,6 @@ Homepage: https://github.com/wirenboard/python-mqtt-rpc
 Package: python3-mqttrpc
 Architecture: all
 XB-Python-Version: ${python3:Version}
-Depends: python3, ${misc:Depends}, ${shlibs:Depends}, python3-jsonrpc | python3-json-rpc, python3-paho-mqtt, python3-wb-common (>= 2.1.0)
+Depends: python3, ${misc:Depends}, ${shlibs:Depends}, python3-jsonrpc, python3-paho-mqtt, python3-wb-common (>= 2.1.0)
 Description: Reference MQTT-RPC implementation
  Python implementation of MQTT-RPC.


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
python3-json-rpc уже давно удален из deb.wirenboard.com реп, вместо него должен использоватся python3-jsonrpc из дебиана. Но на старых инсталяциях он мог остатся, так как не вызывал проблем на булзае, но с новым питоном в трикси уже не работает:
```sh
# wb-diag-collect diag
Traceback (most recent call last):
  File "/usr/bin/wb-diag-collect", line 8, in <module>
    from wb.diag.diag_collect import main  # pylint:disable=wrong-import-position
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/wb-diag-collect/wb/diag/diag_collect.py", line 12, in <module>
    from wb.diag import collector, rpc_server
  File "/usr/share/wb-diag-collect/wb/diag/rpc_server.py", line 11, in <module>
    from mqttrpc import dispatcher
  File "/usr/lib/python3/dist-packages/mqttrpc/__init__.py", line 7, in <module>
    from .manager import MQTTRPCResponseManager  # pylint: disable=wrong-import-position
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/mqttrpc/manager.py", line 4, in <module>
    from jsonrpc.exceptions import (
    ...<7 lines>...
    )
  File "/usr/lib/python3/dist-packages/jsonrpc/__init__.py", line 7, in <module>
    from .dispatcher import Dispatcher
  File "/usr/lib/python3/dist-packages/jsonrpc/dispatcher.py", line 9, in <module>
    class Dispatcher(collections.MutableMapping):
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'collections' has no attribute 'MutableMapping'
```

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


